### PR TITLE
🔨 Fix: RNRN error

### DIFF
--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -6,7 +6,7 @@ Request::Request()
 	this->path = "";
 	this->scheme = "";
 	this->connection = "";
-	this->contentLength = "";
+	this->contentLength = "0";
 	this->state = HEADER_READ;
 }
 
@@ -189,31 +189,10 @@ void	Request::removeCRLF()
 
 int	Request::Findrn0rn(std::string temp)
 {
-	if (temp.find("0\r\n") != std::string::npos)
+	if (temp.find("\r\n0\r\n") != std::string::npos)
 		return (1);
 	else
 		return (0);
-	// std::vector <char>::iterator it;
-	// for (it = this->body.begin(); it != this->body.end(); it++)
-	// {
-	// 	if (*it == '\r')
-	// 	{
-	// 		if (it + 1 < this->body.end() && *(it + 1) == '\n')
-	// 		{
-	// 			if (it + 2 < this->body.end() && *(it + 2) == '0')
-	// 			{
-	// 				if (it + 3 < this->body.end() && *(it + 3) == '\r')
-	// 				{
-	// 					if (it + 4 < this->body.end() && *(it + 4) == '\n')
-	// 					{
-	// 						return (1);
-	// 					}
-	// 				}
-	// 			}
-	// 		}
-	// 	}
-	// }
-	// return (0);
 }
 
 void	Request::AddRNRNOneTime()
@@ -227,40 +206,3 @@ void	Request::RemoveRNRNOneTime()
 	this->body.erase(this->body.begin());
 	this->body.erase(this->body.begin());
 }
-
-// void Request::parsingFromData(std::string data)
-// {
-//     // max size_error 가정
-//     //throw std::runtime_error("client body size error");
-
-//     //test code
-// 	std::stringstream stream;
-// 	stream.str(data);
-
-//     std::string method;
-//     stream >> method;
-//     stream >> this->path;
-
-// 	std::string s;
-// 	while (stream >> s)
-// 	{
-// 		if (s == "Content-Length:")
-// 			stream >> this->contentLength;
-// 		if (s == "Content-Type:")
-// 			stream >> this->contentType;
-// 	}
-
-// 	size_t bodyStart = data.find("\r\n\r\n") + 4; // 빈 줄 다음부터 본문
-//     this->body = data.substr(bodyStart, this->contentLength);
-
-
-//     this->host.push_back("localhost:8080");
-//     if (method == "GET")
-//         this->httpMethod = "GET";
-//     else if (method == "POST")
-//         this->httpMethod = "POST";
-//     else if (method == "PUT")
-//         this->httpMethod = "PUT";
-//     else if (method == "DELETE")
-//         this->httpMethod = "DELETE";
-// }

--- a/src/server/HandleData.cpp
+++ b/src/server/HandleData.cpp
@@ -20,8 +20,6 @@ int	Webserv::SockReceiveData(void) {
 			if (wit->get_server_socket() == mapter->second)
 				break ;
 		ssize_t len = readData(curr_event->ident, buffer.data(), BUFFER_SIZE);
-		//std::cout << buffer.data() << "\n" << std::endl;
-		//데이터 읽기
 		if (len > 0)
 		{
 			if (StartReceiveData(len) == -1)
@@ -92,17 +90,11 @@ int	Webserv::ReadHeader(void) {
 		else if (eventData->request.getHeaders().find("Transfer-Encoding") != std::string::npos)
 		{
 			eventData->request.AddRNRNOneTime();
-			if (eventData->request.Findrn0rn(eventData->request.getBodyCharToStr()) == 1)
+			std::string temp = eventData->request.getBodyCharToStr();
+			if (eventData->request.Findrn0rn(temp) == 1)
 				eventData->request.setState(READ_FINISH);
 			else
 				eventData->request.setState(BODY_READ);
-			// eventData->request.appendBodyStr(temp_data);
-			// std::string temp_str = eventData->request.getBodyStr();
-			// if (eventData->request.Findrn0rn(temp_str) == 1)
-			// 	eventData->request.setState(READ_FINISH);
-			// else
-			// 	eventData->request.setState(BODY_READ);
-
 		}
 		else
 			eventData->request.setState(READ_FINISH);
@@ -121,15 +113,18 @@ void	Webserv::ReadBody(void) {
 	}
 	else if (eventData->request.getHeaders().find("Transfer-Encoding") != std::string::npos)
 	{
-		std::cout << "body_size = " << eventData->request.getBody().size() << std::endl;
 		if (eventData->request.Findrn0rn(temp) == 1)
 			eventData->request.setState(READ_FINISH);
+	}
 }
 
 void	Webserv::ReadFinish(void) {
 	wit->requestHeaderParse(eventData->request);
 	if (eventData->request.getHeaders().find("Transfer-Encoding") != std::string::npos)
+	{
+		eventData->request.RemoveRNRNOneTime();
 		wit->chunkBodyParse(eventData->request, eventData->response);
+	}
 	ChangeEvent(change_list, curr_event->ident, EVFILT_READ, EV_DISABLE, 0, 0, curr_event->udata);
 	ChangeEvent(change_list, curr_event->ident, EVFILT_WRITE, EV_ENABLE, 0, 0, curr_event->udata);	//write 이벤트 발생
 	try


### PR DESCRIPTION
## 📌 Related Issues
- #14 의 14번 테케

## 📝 Description
0rn을 찾아서 read_finish로 가도록 했는데 8000rn 처럼 숫자가 들어왔을 때, 0rn이 아님에도 0rn으로 인식해서 body_read로 가야함에도 read_finish로 가버려서 해당 내용을 정정해 rn0rn을 찾아야 read_finish로 가도록 수정했습니다.
하지만 2번 test case에서는 헤더 다음 바로 0rn이 들어오기 떄문에 rn0rn을 찾을 수 없으므로 처음에 body의 맨 앞에 rn을 강제로 추가하고 파싱하기 전에 rn을 제거하는 방식을 통해 모든 경우에 가능하도록 처리해줬습니다.

## 🌳 Working Branch
- `fix/transfer-encoding`

## 📚 Etc
<!-- 참고할 사항이 있다면 적어주세요 -->
